### PR TITLE
Changed focul to focal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ RELEASE_DIR=/var/www/html
 
 SCP=dark-hitoyoshi-1876@ssh-1.mc.lolipop.jp
 SSH=-p 33641 dark-hitoyoshi-1876@ssh-1.mc.lolipop.jp
-PRODUCT_CODES=centos jessie stretch xenial bionic focul debian
+PRODUCT_CODES=centos jessie stretch xenial bionic focal debian
 build_dir:
 	rm -rf builds && mkdir builds
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,16 +26,16 @@ services:
       - ./repo:/opt/pkg/repo
     environment:
       - DIST=xenial
-  debrepo-focul:
+  debrepo-focal:
     build:
       context: .
       dockerfile: dockerfiles/Dockerfile.debrepo
       args:
-        DIST: focul
+        DIST: focal
     volumes:
       - ./repo:/opt/pkg/repo
     environment:
-      - DIST=focul
+      - DIST=focal
   debrepo-jessie:
     build:
       context: .


### PR DESCRIPTION
The codename for Ubuntu was misspelled...

```
lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.1 LTS
Release:        20.04
Codename:       focal
```
